### PR TITLE
Theming - Take 2

### DIFF
--- a/MyShowcase.xcodeproj/project.pbxproj
+++ b/MyShowcase.xcodeproj/project.pbxproj
@@ -756,7 +756,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ciaranmul/MyStyles";
 			requirement = {
-				branch = main;
+				branch = rwgrier/poc/theme;
 				kind = branch;
 			};
 		};

--- a/MyShowcase.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyShowcase.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
         "package": "MyStyles",
         "repositoryURL": "https://github.com/ciaranmul/MyStyles",
         "state": {
-          "branch": "main",
-          "revision": "b8cbdfbe679c34ed7bec2e546161c9edc4576286",
+          "branch": "rwgrier/poc/theme",
+          "revision": "6dd33c9071463500aca69f8a0cc2d08b62752dd9",
           "version": null
         }
       }

--- a/Shared/MyColorsPreviewView.swift
+++ b/Shared/MyColorsPreviewView.swift
@@ -9,34 +9,62 @@ import SwiftUI
 import MyStyles
 
 struct MyColorsPreviewView: View {
+    @Environment(\.themeEngine) internal var themeEngine
+    @State private var showThemeActionSheet = false
 
     var categories: [ColorCategory] = [
         ColorCategory(name: "Surfaces", colorDetails: [
-            ColorDetails(name: "surface", color: .surface),
-            ColorDetails(name: "background", color: .background)
+            ColorDetails(name: "surface", colorToken: .surface),
+            ColorDetails(name: "background", colorToken: .background)
+        ]),
+        ColorCategory(name: "Surfaces (Inverse)", colorDetails: [
+            ColorDetails(name: "surfaceInverse", colorToken: .surfaceInverse),
+            ColorDetails(name: "backgroundInverse", colorToken: .backgroundInverse)
         ]),
         ColorCategory(name: "Content", colorDetails: [
-            ColorDetails(name: "content", color: .content),
-            ColorDetails(name: "contentSubtle", color: .contentSubtle),
-            ColorDetails(name: "contentDisabled", color: .contentDisabled),
-            ColorDetails(name: "contentSuccess", color: .contentSuccess),
-            ColorDetails(name: "contentCritical", color: .contentCritical),
-            ColorDetails(name: "border", color: .border),
-            ColorDetails(name: "divider", color: .divider)
+            ColorDetails(name: "content", colorToken: .content),
+            ColorDetails(name: "contentSubtle", colorToken: .contentSubtle),
+            ColorDetails(name: "contentDisabled", colorToken: .contentDisabled),
+            ColorDetails(name: "contentSuccess", colorToken: .contentSuccess),
+            ColorDetails(name: "contentCritical", colorToken: .contentCritical),
+            ColorDetails(name: "border", colorToken: .border),
+            ColorDetails(name: "divider", colorToken: .divider)
+        ]),
+        ColorCategory(name: "Content (Inverse)", colorDetails: [
+            ColorDetails(name: "contentInverse", colorToken: .contentInverse),
+            ColorDetails(name: "contentSubtleInverse", colorToken: .contentSubtleInverse),
+            ColorDetails(name: "contentDisabledInverse", colorToken: .contentDisabledInverse),
+            ColorDetails(name: "contentSuccessInverse", colorToken: .contentSuccessInverse),
+            ColorDetails(name: "contentCriticalInverse", colorToken: .contentCriticalInverse),
+            ColorDetails(name: "borderInverse", colorToken: .borderInverse),
+            ColorDetails(name: "dividerInverse", colorToken: .dividerInverse)
         ]),
         ColorCategory(name: "Actions", colorDetails: [
-            ColorDetails(name: "actionPrimarySlice", color: .actionPrimary),
-            ColorDetails(name: "actionPrimaryBold", color: .actionPrimaryBold),
-            ColorDetails(name: "actionSecondary", color: .actionSecondary),
-            ColorDetails(name: "actionDisabled", color: .actionDisabled),
-            ColorDetails(name: "actionIcon", color: .actionIcon),
+            ColorDetails(name: "actionPrimarySlice", colorToken: .actionPrimary),
+            ColorDetails(name: "actionPrimaryBold", colorToken: .actionPrimaryBold),
+            ColorDetails(name: "actionSecondary", colorToken: .actionSecondary),
+            ColorDetails(name: "actionDisabled", colorToken: .actionDisabled),
+            ColorDetails(name: "actionIcon", colorToken: .actionIcon)
+        ]),
+        ColorCategory(name: "Actions (Inverse)", colorDetails: [
+            ColorDetails(name: "actionPrimaryInverse", colorToken: .actionPrimaryInverse),
+            ColorDetails(name: "actionPrimaryBoldInverse", colorToken: .actionPrimaryBoldInverse),
+            ColorDetails(name: "actionSecondaryInverse", colorToken: .actionSecondaryInverse),
+            ColorDetails(name: "actionDisabledInverse", colorToken: .actionDisabledInverse)
         ]),
         ColorCategory(name: "Rating Scale", colorDetails: [
-            ColorDetails(name: "rating9", color: .rating9),
-            ColorDetails(name: "rating8", color: .rating8),
-            ColorDetails(name: "rating7", color: .rating7),
-            ColorDetails(name: "rating6", color: .rating6),
-            ColorDetails(name: "rating5", color: .rating5),
+            ColorDetails(name: "rating9", colorToken: .rating9),
+            ColorDetails(name: "rating8", colorToken: .rating8),
+            ColorDetails(name: "rating7", colorToken: .rating7),
+            ColorDetails(name: "rating6", colorToken: .rating6),
+            ColorDetails(name: "rating5", colorToken: .rating5),
+        ]),
+        ColorCategory(name: "Rating Scale (Inverse)", colorDetails: [
+            ColorDetails(name: "rating9Inverse", colorToken: .rating9Inverse),
+            ColorDetails(name: "rating8Inverse", colorToken: .rating8Inverse),
+            ColorDetails(name: "rating7Inverse", colorToken: .rating7Inverse),
+            ColorDetails(name: "rating6Inverse", colorToken: .rating6Inverse),
+            ColorDetails(name: "rating5Inverse", colorToken: .rating5Inverse),
         ])
     ]
 
@@ -44,13 +72,38 @@ struct MyColorsPreviewView: View {
         List(categories, id: \.self) { category in
             MyColorCategoryView(category: category)
         }
+        .navigationTitle("Colors - \(themeEngine.currentThemeType.description)")
+        .toolbar {
+            Button("Change Theme") {
+                self.showThemeActionSheet = true
+            }
+        }
+        .actionSheet(isPresented: $showThemeActionSheet) {
+            ActionSheet(title: Text("Change the theme"),
+                        message: nil,
+                        buttons: [
+                            .default(Text(ThemeType.legacy.description),
+                                     action: {
+                                         themeEngine.set(.legacy)
+                                     }),
+                            .default(Text(ThemeType.metalabsv1.description),
+                                     action: {
+                                         themeEngine.set(.metalabsv1)
+                                     }),
+                            .default(Text(ThemeType.silly.description),
+                                     action: {
+                                         themeEngine.set(.silly)
+                                     }),
+                            .cancel()
+                        ])
+        }
     }
 }
 
 struct ColorDetails: Hashable {
     var id: UUID = UUID()
     var name: String
-    var color: MyColor
+    var colorToken: ColorToken
 }
 
 struct ColorCategory: Hashable {
@@ -65,7 +118,7 @@ struct MyColorCategoryView: View {
     var body: some View {
         Section {
             ForEach(category.colorDetails, id: \.self) { color in
-                MyColorPreview(color.name, color.color)
+                MyColorPreview(color.name, color.colorToken)
             }
         } header: {
             Text(category.name)
@@ -75,18 +128,18 @@ struct MyColorCategoryView: View {
 
 struct MyColorPreview: View {
     var text: String
-    var color: MyColor
+    var colorToken: ColorToken
 
-    init(_ text: String, _ color: MyColor) {
+    init(_ text: String, _ color: ColorToken) {
         self.text = text
-        self.color = color
+        self.colorToken = color
     }
 
     var body: some View {
         HStack {
             Circle()
-                .foregroundColor(color)
-                .overlay(Circle().stroke(MyColor.border, lineWidth: 1))
+                .foregroundColor(colorToken)
+                .overlay(Circle().stroke(.border, lineWidth: 1))
                 .frame(width: 20, height: 20, alignment: .leading)
             Text(text)
             Spacer()
@@ -97,5 +150,7 @@ struct MyColorPreview: View {
 struct MyColorsPreviewView_Previews: PreviewProvider {
     static var previews: some View {
         MyColorsPreviewView()
+        MyColorsPreviewView()
+            .themeType(.silly)
     }
 }

--- a/Shared/MyShowcaseApp.swift
+++ b/Shared/MyShowcaseApp.swift
@@ -18,6 +18,7 @@ struct MyShowcaseApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .themeType(.default)
         }
     }
 }


### PR DESCRIPTION
Updated the POC app here to include the new theming engine. This PR uses [this branch](https://github.com/ciaranmul/MyStyles/tree/rwgrier/poc/theme) of `[MyStyles](https://github.com/ciaranmul/MyStyles)`. Before any of this is merged, the branch on the MyStyles swift package will need to be changed back. 

Depends on https://github.com/ciaranmul/MyStyles/pull/5

- Added the inverse colors to the list. 
- Added a mechanism to change the theme. 

Note about changing the theme: 
This may be another inexperience issue, or something silly I did. But I added a bit of a hack to force the list of colors to refresh when the theme changes. I'm sure there's a better way to do this. I also figure that this may be OK. Since in the real shipping app, we're not going to be changing the colors on the fly. Instead, we'll likely get the theme info from a feature flag and update it that way instead of allowing users to flip/flop back and forth between the themes. The spot where I have the hack is documented/commented with why I added it and how it works. 

Without this hack above, the theme would still change globally, the current view would not be updated until you either scroll or navigate away and then back. I think that's probably OK for the shipping app. But if it's not, I'll be open to ideas here. 

Some screenshots. 
![Simulator Screen Shot - iPhone 13 Pro Max - 2021-10-14 at 13 52 33](https://user-images.githubusercontent.com/930941/137370686-42dac38f-4394-41f0-9c81-2b6d8e35e3a0.png)
![Simulator Screen Shot - iPhone 13 Pro Max - 2021-10-14 at 13 52 36](https://user-images.githubusercontent.com/930941/137370690-41e8b78e-74d0-463a-bcf5-0348328c458c.png)
![Simulator Screen Shot - iPhone 13 Pro Max - 2021-10-14 at 13 52 40](https://user-images.githubusercontent.com/930941/137370692-65e921c5-b6ac-4012-a4b4-80750db84e60.png)


